### PR TITLE
use ports to install freebsd package

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -64,6 +64,13 @@ class sudo::package(
       }
     }
     'Darwin': {}
+    'FreeBSD': {
+      class { '::sudo::package::freebsd':
+        package        => $package,
+        package_source => $package_source,
+        package_ensure => $package_ensure,
+      }
+    }
     'Solaris': {
       class { '::sudo::package::solaris':
         package            => $package,

--- a/manifests/package/freebsd.pp
+++ b/manifests/package/freebsd.pp
@@ -1,0 +1,13 @@
+class sudo::package::freebsd (
+  $package = '',
+  $package_source = '',
+  $package_ensure = 'present',
+
+  ) {
+
+    package { $package:
+      ensure   => $package_ensure,
+      source   => $package_source,
+      provider => 'pkgng',
+    }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -119,7 +119,7 @@ class sudo::params {
       }
     }
     'FreeBSD': {
-      $package = 'security/sudo'
+      $package = 'sudo'
       $package_ldap = undef
       $package_ensure = 'present'
       $package_source = ''


### PR DESCRIPTION
Puppet was defaulting to `pip3` to install `sudo`, as opposed to `ports` which was the intended method to optionally compile support for LDAP.

This PR switches to the `pkgng` provider (neither `pkg` nor `freebsd` are compatible with FreeBSD 10.x apparently), which forgoes the ability to optionally compile support for LDAP.